### PR TITLE
variable names

### DIFF
--- a/Cassandra.php
+++ b/Cassandra.php
@@ -125,7 +125,7 @@ class Zend_Cassandra
 		
 		$mutation[$columnFamily] = $columns;
 		
-		$this->client->batch_insert($this->keyspace, $key, $mutation, $consistency);
+		$this->_client->batch_insert($this->_keyspace, $key, $mutation, $consistency);
 	}
 	
 	/**


### PR DESCRIPTION
two class properties had the wrong name (client instead of _ client and keyspace instead of _ keyspace), just changed them :-)
